### PR TITLE
Remove check open url when thread is not main.

### DIFF
--- a/IOSSecuritySuite/JailbreakChecker.swift
+++ b/IOSSecuritySuite/JailbreakChecker.swift
@@ -116,14 +116,7 @@ internal class JailbreakChecker {
 
         if Thread.isMainThread {
             flag = canOpenUrlFromList(urlSchemes: urlSchemes)
-        } else {
-            let semaphore = DispatchSemaphore(value: 0)
-            DispatchQueue.main.async {
-                flag = canOpenUrlFromList(urlSchemes: urlSchemes)
-                semaphore.signal()
-            }
-            semaphore.wait()
-        }
+        } 
         return flag
     }
 


### PR DESCRIPTION
## Why
main.sync 還是會在 sync thread 的時候 crash.
## How
因為 url 檢查只是其中一小段. 所以移除不是main thread 的檢查。
不然這是個無解的問題。